### PR TITLE
remove styled-components from final bundle and add to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "jsnext:main": "dist/formidable-oss-badges.es.js",
   "module": "dist/formidable-oss-badges.es.js",
   "dependencies": {
-    "buble": "0.19.6",
     "styled-components": "4.1.1"
   },
   "devDependencies": {
@@ -18,6 +17,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.3.2",
     "babel-preset-react": "^6.23.0",
+    "buble": "0.19.6",
     "react": "16.8.3",
     "rollup": "^0.55.3",
     "rollup-plugin-babel": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "jsnext:main": "dist/formidable-oss-badges.es.js",
   "module": "dist/formidable-oss-badges.es.js",
   "dependencies": {
-    "buble": "0.19.6"
+    "buble": "0.19.6",
+    "styled-components": "4.1.1"
   },
   "devDependencies": {
     "babel-core": "6.26.3",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "dist/formidable-oss-badges.cjs.js",
   "jsnext:main": "dist/formidable-oss-badges.es.js",
   "module": "dist/formidable-oss-badges.es.js",
-  "dependencies": {
-    "styled-components": "4.1.1"
+  "peerDependencies": {
+    "styled-components": ">= 4.0.0"
   },
   "devDependencies": {
     "babel-core": "6.26.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,7 +58,7 @@ const prodPlugins = plugins.concat([
 
 const base = {
   input: 'src/index.js',
-  external: ['react', 'react-dom', 'prismjs', 'buble']
+  external: ['react', 'react-dom', 'prismjs', 'buble', 'styled-components']
 };
 
 const output = {


### PR DESCRIPTION
We bundled our own version of styled-components inside the final bundle, this prevents that and uses one from dependencies (can be shared with root project)