### PR TITLE
Prevent pass through of isHoverable prop to svg node.

### DIFF
--- a/src/FeaturedBadge.js
+++ b/src/FeaturedBadge.js
@@ -6,7 +6,7 @@ import featuredLogos from "./assets/featuredLogos";
 const FeaturedBadge = ({ name, className, isHoverable }) => {
   const Logo = featuredLogos[name.toLowerCase()];
   if (!Logo) return null;
-  const StyledLogo = styled(Logo)`
+  const StyledLogo = styled(({ isHoverable, ...rest }) => <Logo {...rest} />)`
     ${({ isHoverable }) =>
       isHoverable &&
       `


### PR DESCRIPTION
I noticed a small error when bringing this project into the `renature` docs. We don't actually remove the `isHoverable` prop from the props that get passed through to the underlying `svg` node rendered by `FeaturedBadge`, which results in good ol' warnings like this one:

<img width="249" alt="image" src="https://user-images.githubusercontent.com/19421190/82273459-cb870d80-993a-11ea-8336-753b5fc7cc17.png">

This fix just ensures we remove `isHoverable` before it's passed onto the `svg` itself.