### PR TITLE
FeaturedBadge: Move `styled` outside of the render function

### DIFF
--- a/src/FeaturedBadge.js
+++ b/src/FeaturedBadge.js
@@ -3,7 +3,13 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import featuredLogos from "./assets/featuredLogos";
 
-const StyledLogo = styled.svg`
+const StyledLogo = styled(({ tagName, isHoverable, ...props }) => {
+  const Component = tagName || "svg";
+  // Do not forward `isHoverable` to DOM
+  // This method can be replaced with `styled.svg.withConfig({ shouldForwardProp: ... })`
+  // with styled-components@v5.1
+  return <Component {...props} />;
+})`
   ${(props) =>
     props.isHoverable &&
     `
@@ -27,7 +33,11 @@ const FeaturedBadge = ({ name, className, isHoverable }) => {
   if (!Logo) return null;
 
   return (
-    <StyledLogo as={Logo} className={className} isHoverable={isHoverable} />
+    <StyledLogo
+      tagName={Logo}
+      className={className}
+      isHoverable={isHoverable}
+    />
   );
 };
 

--- a/src/FeaturedBadge.js
+++ b/src/FeaturedBadge.js
@@ -3,27 +3,32 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import featuredLogos from "./assets/featuredLogos";
 
+const StyledLogo = styled.svg`
+  ${(props) =>
+    props.isHoverable &&
+    `
+      .inner-ring,
+      .outer-ring {
+        transition: 0.3s;
+      }
+
+      &:hover .inner-ring {
+        opacity: 0.3;
+      }
+
+      &:hover .outer-ring {
+        opacity: 0.6;
+      }
+  `}
+`;
+
 const FeaturedBadge = ({ name, className, isHoverable }) => {
   const Logo = featuredLogos[name.toLowerCase()];
   if (!Logo) return null;
-  const StyledLogo = styled(({ isHoverable, ...rest }) => <Logo {...rest} />)`
-    ${({ isHoverable }) =>
-      isHoverable &&
-      `
-    .inner-ring,
-    .outer-ring {
-      transition: 0.3s;
-    }
 
-    &:hover .inner-ring {
-      opacity: 0.3;
-    }
-
-    &:hover .outer-ring {
-      opacity: 0.6;
-    }`}
-  `;
-  return <StyledLogo className={className} isHoverable={isHoverable} />;
+  return (
+    <StyledLogo as={Logo} className={className} isHoverable={isHoverable} />
+  );
 };
 
 FeaturedBadge.propTypes = {


### PR DESCRIPTION
👋 

This PR resolves the following console warning for the `<FeaturedBage>` component: 
```
The component Styled(Component) with the id of "sc-fzqAui" has been created dynamically.
You may see this warning because you've called styled inside another component.
To resolve this only create new StyledComponents outside of any render method and function component. 
```

This PR: 
- Move `styled` outside of the `render` function 
- Pass the `Logo` component as a `tagName` prop, so the badge can be rendered without passing `isHoverable` to the DOM. This approach can be revisited once `styled-components` is upgraded to at least v5.1.0.

