### PR TITLE
Adds support for exporting featured badge names

### DIFF
--- a/.changeset/flat-suns-run.md
+++ b/.changeset/flat-suns-run.md
@@ -1,0 +1,5 @@
+---
+"formidable-oss-badges": minor
+---
+
+Adds support for exporting available badges as an array

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Badges for Formidable Open Source Projects
 - [FeaturedBadge](#featuredbadge)
   - [Available badges](#available-badges)
   - [Usage](#featuredbadge-usage)
-- [IconBadge](#iconbadge)
-  - [Component props](#iconbadge-props)
-  - [Component children](#iconbadge-children)
-  - [Usage](#iconbadge-usage)
 - [Examples](#examples)
 - [Try component locally](#try-the-component-locally)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,6 @@
+import * as featuredLogos from "./assets/featuredLogos"
+
 export { default as ProjectBadge } from "./ProjectBadge"
 export { default as FeaturedBadge } from "./FeaturedBadge"
+
+export const featuredBadgeNames = Object.keys(featuredLogos.default)


### PR DESCRIPTION
Adds support for dynamically exporting the available badge names so we can use it as a pick list in Sanity studio and avoid hard coding and things getting out of date.

<img width="212" alt="Screenshot 2023-04-04 at 9 15 29 AM" src="https://user-images.githubusercontent.com/1738349/229821421-40e9232d-3cc7-4bc8-9fb6-0c3f7ce1b237.png">
