### PR TITLE
add rest props spread for using ProjectBadge in the OSS Banner context

### DIFF
--- a/.changeset/kind-candles-fail.md
+++ b/.changeset/kind-candles-fail.md
@@ -1,0 +1,6 @@
+---
+"formidable-oss-badges": patch
+---
+
+Enable ProjectBadge to accept additional props for use in OSS Banner - matching
+FeaturedBadge"

--- a/src/ProjectBadge.tsx
+++ b/src/ProjectBadge.tsx
@@ -52,6 +52,7 @@ const ProjectBadge = (props: Props) => {
     style,
     isHoverable = true,
     simple = false,
+    ...rest
   } = props
   let baseY = BASE_Y
   if (simple) {
@@ -64,6 +65,7 @@ const ProjectBadge = (props: Props) => {
         viewBox="0 0 600 595"
         className={clsx(isHoverable && styles.hoverableLogo, className)}
         style={style}
+        {...rest}
       >
         <g fill="none" fillRule="evenodd">
           <path


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

adding space for contextual props via `...rest` to allow the badge to be used in the OSS banner generator.
